### PR TITLE
Fix: annotation

### DIFF
--- a/src/transformers/integrations/integration_utils.py
+++ b/src/transformers/integrations/integration_utils.py
@@ -2198,9 +2198,9 @@ class SwanLabCallback(TrainerCallback):
             release
 
         - **SWANLAB_WEB_HOST** (`str`, *optional*, defaults to `None`):
-                Web address for the SwanLab cloud environment for private version (its free)
+            Web address for the SwanLab cloud environment for private version (its free)
 
-        - **SWANLAB_WEB_HOST** (`str`, *optional*, defaults to `None`):
+        - **SWANLAB_API_HOST** (`str`, *optional*, defaults to `None`):
             API address for the SwanLab cloud environment for private version (its free)
 
         """


### PR DESCRIPTION
This pull request includes a change to the `setup` method in the `integration_utils.py` file. The change corrects the parameter name from `SWANLAB_WEB_HOST` to `SWANLAB_API_HOST` to accurately reflect its purpose.

* [`src/transformers/integrations/integration_utils.py`](diffhunk://#diff-70576373928eee203a92800d5ea1f6270d45462a9bde494cde65338710a0a331L2203-R2203): Corrected the parameter name from `SWANLAB_WEB_HOST` to `SWANLAB_API_HOST` in the `setup` method to accurately describe the API address for the SwanLab cloud environment.